### PR TITLE
Simplifying Data Storage to a single file as a Pandas Dataframe 

### DIFF
--- a/SPARCED/src/simulation/utils/output.py
+++ b/SPARCED/src/simulation/utils/output.py
@@ -1,33 +1,37 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import numpy as np
 import pandas as pd
+from utils.combine_results import combine_results
 
 
 def save_simulation_output(model, simulation_name: str, simulation_number: int,
-                           output_sim: str, xoutS_all: np.ndarray,
+                           output_sim: str, xoutS_all: np.ndarray, 
                            xoutG_all: np.ndarray, tout_all: np.ndarray) -> None:
     """
-    Save simulation results in three files: species, genes and time
+    Save simulation output to a txt file
+
+    Parameters:
+    - model: model object
+    - simulation_name (str): name of the simulation
+    - simulation_number (int): number of the simulation
+    - output_sim (str): path to the output directory
+    - xoutS_all (np.ndarray): array of species values
+    - xoutG_all (np.ndarray): array of gene values
+    - tout_all (np.ndarray): array of time values
+
+    Returns:
+    - None
     """
 
-    # TODO: ensure that the last character of the output_sim parameter is a dash,
+    # ensure that the last character of the output_sim parameter is a dash,
     # otherwise if verbose ask the user if he meant to add one
     # Species
-    columnsS = [ele for ele in model.getStateIds()]
-    condsSDF = pd.DataFrame(data = xoutS_all, columns = columnsS)
-    condsSDF.to_csv(output_sim + simulation_name + '_S_' + str(simulation_number) + '.txt', sep="\t")
-    condsSDF = None
-    # Genes
-    columnsG = [x for n, x in enumerate(columnsS) if 'm_' in x]
-    columnsG = columnsG[1:] # Skip header
-    resa = [sub.replace('m_', 'ag_') for sub in columnsG]
-    resi = [sub.replace('m_', 'ig_') for sub in columnsG]
-    columnsG2 = np.concatenate((resa, resi), axis=None)
-    condsGDF = pd.DataFrame(data = xoutG_all, columns = columnsG2)
-    condsGDF.to_csv(output_sim + simulation_name + '_G_' + str(simulation_number) + '.txt', sep="\t")
-    condsGDF = None
-    # Time
-    np.savetxt(output_sim + simulation_name + '_T_' + str(simulation_number) + '.txt', tout_all, newline="\t", fmt="%s")
+    assert output_sim[-1] == os.path.sep, f'The output directory must end with a "{os.path.sep}" character.'
+
+    simulation_results = combine_results(model, xoutS_all, xoutG_all, tout_all)
+
+    simulation_results.to_csv(output_sim + simulation_name + '_' + str(simulation_number) + '.txt', sep="\t")
 

--- a/SPARCED/src/utils/combine_results.py
+++ b/SPARCED/src/utils/combine_results.py
@@ -1,0 +1,51 @@
+#!/bin/bash python3
+# -*- coding: utf-8 -*-
+
+#------------------------------------------------------------------------------#
+# script name: combine_results.py
+# Author: Aurore Amrit & Jonah R. Huggins
+# Created on: Tues. Dec. 10th, 2024
+
+# Description: Script to concatenate the results of the SPARCED model into a single
+# dataframe. This script is only compatible with the SPARCED model results.
+#------------------------------------------------------------------------------#
+
+import os
+import sys
+import pickle
+import numpy as np
+import pandas as pd
+
+def combine_results(model, xoutS_all: np.ndarray, 
+                    xoutG_all: np.ndarray, tout_all: np.ndarray) -> None:
+    """
+    Takes nested array results of genes, mRNA, proteins, and time values and 
+    concatentates them into a single dataframe. 
+
+    Parameters:
+        - model: model object
+        - xoutS_all (np.ndarray): array of species values
+        - xoutG_all (np.ndarray): array of gene values
+        - toutS_all (np.ndarray): array of time values
+
+    Output:
+        - pd.DataFrame: dataframe of concatenated results
+    """
+    # Create a dataframe to store the results
+    sparced_results = pd.DataFrame(data = tout_all, columns = ['time'])
+
+    # Get the gene and species names from the model
+    species_names = model.getStateIds()
+    gene_data = [x for n, x in enumerate(species_names) if 'm_' in x]
+    
+    # Add species to the results dictionary
+    sparced_results = pd.concat([sparced_results, pd.DataFrame(data = xoutS_all, columns = species_names)], axis=1)
+
+    # Add genes to the results dictionary
+    gene_data = gene_data[1:] # Skip header
+    resa = [sub.replace('m_', 'ag_') for sub in gene_data]
+    resi = [sub.replace('m_', 'ig_') for sub in gene_data]
+    gene_data2 = np.concatenate((resa, resi), axis=None)
+    sparced_results = pd.concat([sparced_results, pd.DataFrame(data = xoutG_all, columns = gene_data2)], axis=1)
+
+    return sparced_results


### PR DESCRIPTION
I extracted the contents of `SPARCED/src/simulation/utils/output.py` and modified them in another file, `SPARCED/src/utils/combine_results.py` for general function access. 

I then modified `SPARCED/src/simulation/utils/output.py` to reflect this change accordingly. This should result in no modifications to the results saved, nor workflow operation. The only difference is that the number of files saved has been reduced down to 1 .txt file (pandas dataframe structure). A `pd.DataFrame` format was chosen because, despite being marginally more memory and storage exhaustive than an `np.ndarray` structure, they enable labeled indexing. Therefore we are able to index 'time', 'species', and 'genes' from one single results file.

If approved, I will modify the benchmarking pipeline results storage accordingly.